### PR TITLE
Added git branch --delete command

### DIFF
--- a/commands/Git-commands.md
+++ b/commands/Git-commands.md
@@ -106,7 +106,7 @@ Collaborate (see also: git help workflows):
 | `git branch [branch name]` | Create a new branch |
 | `git branch -d [branch name]` | Delete a branch |
 | `git branch -m [old branch name] [new branch name]` | Rename a local branch |
-
+| `git push --delete origin [branch name]` | Delete a branch on remote repository |
 
 ## Checkout
 
@@ -137,7 +137,7 @@ Collaborate (see also: git help workflows):
 | `git push` | Push changes to remote repository (remembered branch) |
 | `git push origin [branch name]` | Push a branch to your remote repository |
 | `git push -u origin [branch name]` | Push changes to remote repository (and remember the branch) |
-| `git push origin --delete [branch name]` | Delete a remote branch |
+| `git push --delete origin [branch name]` | Delete a branch on remote repository |
 
 ## Pull
 


### PR DESCRIPTION
Greetings fellow learners and contributors,

This pull request is an exciting addition to our Git learning repository. We're introducing the `git push --delete` command.

***Changes Introduced:***

Added a new command: `git push --delete <branch_name>`
The command guides users through the process of deleting a remote branch.

***Example:***

Let's consider a scenario. Say we have a remote branch named feature/add-widget. To safely delete it using the new command, execute:

```
git --delete feature/add-widget
```

***Contributor's Note:***

As someone passionate about spreading Git knowledge, I'm excited to contribute to this learning repository. The git --delete command is thoughtfully designed to provide valuable hands-on experience while maintaining a commitment to safe learning. I've thoroughly tested the command to ensure it aligns with both Git best practices and our repository's educational goals.

Thank you for considering this contribution.